### PR TITLE
Only list unseen message if --skip-unseen is present

### DIFF
--- a/java/email-fetcher/src/main/java/com/ywesee/java/yopenedi/emailfetcher/App.java
+++ b/java/email-fetcher/src/main/java/com/ywesee/java/yopenedi/emailfetcher/App.java
@@ -15,6 +15,7 @@ import org.apache.commons.cli.*;
 import org.apache.commons.io.IOUtils;
 
 import javax.mail.*;
+import javax.mail.search.FlagTerm;
 import java.io.*;
 import java.util.Properties;
 
@@ -160,20 +161,16 @@ public class App {
 
         inbox.open(Folder.READ_WRITE);
 
-        Message[] ms = inbox.getMessages();
+        Message[] ms = skipSeenMessage
+                ? inbox.search(new FlagTerm(new Flags(Flags.Flag.SEEN), false))
+                : inbox.getMessages();
         System.out.println("Found " + ms.length + " messages");
 
         for (Message message : ms) {
             long uid = inbox.getUID(message);
             System.out.println("Found message. UID=" + uid);
 
-            boolean seen = message.isSet(Flags.Flag.SEEN);
-            if (seen && skipSeenMessage) {
-                System.out.println("Message is seen, skipping.");
-                continue;
-            } else {
-                System.out.println("Getting attachment");
-            }
+            System.out.println("Getting attachment");
             Object content = message.getContent();
             if (!(content instanceof BASE64DecoderStream)) {
                 // handle multipart?


### PR DESCRIPTION
#94 

Es speichert IDs in einer Datei nicht, aber es ignorieret alte Mail, wenn es gibt "--skip-seen". Es werde jetzt alle IDs immer abgefragt nicht.