### PR TITLE
Write Line number item as <LINE_ITEM_ID>

### DIFF
--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/Edifact/EdifactReader.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/Edifact/EdifactReader.java
@@ -138,6 +138,7 @@ public class EdifactReader {
                     OrderItem orderItem = new OrderItem();
                     LINLineItem lineItem = segmentGroup25.getLINLineItem();
                     if (lineItem != null) {
+                        orderItem.lineItemNumber = lineItem.getE1082LineItemNumber();
                         C212ItemNumberIdentification c212id = lineItem.getC212ItemNumberIdentification();
                         if (c212id != null) {
                             if ("EN".equals(c212id.getE7143ItemNumberTypeCoded())) {

--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/Edifact/OrderItem.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/Edifact/OrderItem.java
@@ -3,6 +3,7 @@ package com.ywesee.java.yopenedi.Edifact;
 import java.math.BigDecimal;
 
 public class OrderItem {
+    public BigDecimal lineItemNumber;
     public String ean;
     public String descriptionShort;
     public String descriptionLong;

--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/OpenTrans/Order.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/OpenTrans/Order.java
@@ -165,10 +165,8 @@ public class Order implements Writable {
 
     private void writeOrderItemList(XMLStreamWriter streamWriter) throws XMLStreamException {
         streamWriter.writeStartElement("ORDER_ITEM_LIST");
-        int index = 1;
         for (OrderItem orderItem : this.orderItems) {
-            orderItem.write(streamWriter, index);
-            index++;
+            orderItem.write(streamWriter);
         }
         streamWriter.writeEndElement(); // ORDER_ITEM_LIST
     }

--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/OpenTrans/OrderItem.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/OpenTrans/OrderItem.java
@@ -7,6 +7,7 @@ import java.math.BigDecimal;
 import static com.ywesee.java.yopenedi.converter.Utility.notNullOrEmpty;
 
 public class OrderItem {
+    public BigDecimal lineItemId;
     public String ean;
     public String descriptionShort;
     public String descriptionLong;
@@ -41,11 +42,11 @@ public class OrderItem {
         return this.price.multiply(this.quantity).divide(this.priceQuantity, BigDecimal.ROUND_HALF_UP);
     }
 
-    public void write(XMLStreamWriter s, int index) throws XMLStreamException {
+    public void write(XMLStreamWriter s) throws XMLStreamException {
         s.writeStartElement("ORDER_ITEM");
 
         s.writeStartElement("LINE_ITEM_ID");
-        s.writeCharacters("" + index);
+        s.writeCharacters(this.lineItemId.toString());
         s.writeEndElement(); // LINE_ITEM_ID
 
         s.writeStartElement("PRODUCT_ID");

--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/converter/Converter.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/converter/Converter.java
@@ -140,6 +140,7 @@ public class Converter {
 
     public OrderItem orderItemToOpenTrans(com.ywesee.java.yopenedi.Edifact.OrderItem orderItem) {
         OrderItem oi = new OrderItem();
+        oi.lineItemId = orderItem.lineItemNumber;
         oi.ean = orderItem.ean;
         oi.descriptionShort = orderItem.descriptionShort;
         oi.descriptionLong = orderItem.descriptionLong;


### PR DESCRIPTION
Wenn wir ein Edifact Datei (ORDERS) nach OpenTrans konvertieren:
`LIN+123+...` macht `<LINE_ITEM_ID>123</LINE_ITEM_ID>`.

Wenn wir ein OpenTrans Datei nach Edifact (ORDRSP) konvertieren:
`<LINE_ITEM_ID>123</LINE_ITEM_ID>` macht `LIN+123+...` und `RFF+LI+123...`.

Ist das ok?