### PR TITLE
Add extra party for delivery

### DIFF
--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/Edifact/EdifactReader.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/Edifact/EdifactReader.java
@@ -129,7 +129,6 @@ public class EdifactReader {
                     }
                     order.addParty(party);
                 }
-                order.patchEmptyDeliveryID();
                 for (SegmentGroup7 segmentGroup7 : orders.getSegmentGroup7()) {
                     try {
                         order.currencyCoded = segmentGroup7.getCUXCurrencies().getC5041CurrencyDetails().getE6345CurrencyCoded();

--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/Edifact/Order.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/Edifact/Order.java
@@ -29,16 +29,4 @@ public class Order {
         }
         return null;
     }
-
-    public void patchEmptyDeliveryID() {
-        // It's possible that the delivery party does not have an ID.
-        // In that case we'll set it to ADHOC
-        // https://github.com/zdavatz/yopenedi/issues/176
-        for (Party p : this.parties) {
-            if (p.role == Party.Role.Delivery && (p.id == null || p.id.isEmpty())) {
-                p.id = "ADHOC";
-                break;
-            }
-        }
-    }
 }

--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/OpenTrans/Party.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/OpenTrans/Party.java
@@ -18,6 +18,7 @@ public class Party {
         Supplier,
         Delivery,
         InvoiceRecipient,
+        Other,
     }
 
     public String id;
@@ -35,6 +36,7 @@ public class Party {
 
     public String vatId;
     public String taxNumber;
+    public String addressRemarks;
 
     public Party() {
     }
@@ -161,6 +163,9 @@ public class Party {
                 case InvoiceRecipient:
                     s.writeCharacters("invoice_recipient");
                     break;
+                case Other:
+                    s.writeCharacters("other");
+                    break;
             }
             s.writeEndElement(); // PARTY_ROLE
         }
@@ -212,6 +217,12 @@ public class Party {
             s.writeStartElement("bmecat:COUNTRY_CODED");
             s.writeCharacters(this.countryCoded);
             s.writeEndElement(); // COUNTRY_CODED
+        }
+
+        if (notNullOrEmpty(this.addressRemarks)) {
+            s.writeStartElement("bmecat:ADDRESS_REMARKS");
+            s.writeCharacters(this.addressRemarks);
+            s.writeEndElement(); // ADDRESS_REMARKS
         }
 
         s.writeEndElement(); // ADDRESS

--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/converter/Converter.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/converter/Converter.java
@@ -90,7 +90,7 @@ public class Converter {
                 }
             }
         }
-
+        o.patchEmptyDeliveryID();
         return o;
     }
 


### PR DESCRIPTION
#179

Hat EDIFACT der Tag "NAD+DP...", weil meint `DP` "delivery", es macht diese:

```
NAD+DP+4015828001005::9'
```

```
<PARTY>
	<bmecat:PARTY_ID type="iln">4015828001005</bmecat:PARTY_ID>
	<PARTY_ROLE>delivery</PARTY_ROLE>
	<ADDRESS/>
</PARTY>
<PARTY>
	<bmecat:PARTY_ID type="iln">4015828001005</bmecat:PARTY_ID>
	<PARTY_ROLE>other</PARTY_ROLE>
	<ADDRESS>
		<bmecat:ADDRESS_REMARKS>Konditionsadresse</bmecat:ADDRESS_REMARKS>
	</ADDRESS>
</PARTY>
```

Hat EDIFACT der Tag "NAD+IV...", weil meint `IV` "invoice_recipient", es macht diese:

```
NAD+IV+4015828000005::9'
```

```
<PARTY>
	<bmecat:PARTY_ID type="iln">4015828000008</bmecat:PARTY_ID>
	<PARTY_ROLE>invoice_recipient</PARTY_ROLE>
	<ADDRESS/>
</PARTY>
```

Ist das ok?