### PR TITLE
Nachrichten via SFTP X.400

### DIFF
--- a/java/conf/sftpx400-credential.json
+++ b/java/conf/sftpx400-credential.json
@@ -1,0 +1,7 @@
+{
+  "host": "example.com",
+  "username": "<username>",
+  "privateKeyPath": "/path/to/private/key",
+  "knownHosts": "example.com ssh-rsa AAAAAAAAA==",
+  "messageFolder": "sftp-x400-messages"
+}

--- a/java/conf/test-sftpx400-credential.json
+++ b/java/conf/test-sftpx400-credential.json
@@ -1,0 +1,7 @@
+{
+  "host": "example.com",
+  "username": "<username>",
+  "privateKeyPath": "/path/to/private/key",
+  "knownHosts": "example.com ssh-rsa AAAAAAAAA==",
+  "messageFolder": "sftp-x400-messages"
+}

--- a/java/converter/build.gradle
+++ b/java/converter/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.7'
 
     compile group: 'javax.mail', name: 'mail', version: '1.5.0-b01'
+    implementation 'com.jcraft:jsch:0.1.55'
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     // implementation 'com.google.guava:guava:28.0-jre'

--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/common/Config.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/common/Config.java
@@ -6,10 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import com.ywesee.java.yopenedi.Edifact.DespatchAdvice;
-import com.ywesee.java.yopenedi.Edifact.Invoice;
-import com.ywesee.java.yopenedi.Edifact.OrderResponse;
-import com.ywesee.java.yopenedi.Edifact.Party;
 import org.apache.commons.io.FileUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -59,6 +55,26 @@ public class Config {
         System.out.println("Reading from " + f.getAbsolutePath());
         try {
             return new EmailCredential(f);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            return null;
+        }
+    }
+
+    public SFTPX400 getSFTPX400Credential() {
+        if (isTest) {
+            File f = new File(this.path, "test-sftpx400-credential.json");
+            System.out.println("Reading from " + f.getAbsolutePath());
+            try {
+                return new SFTPX400(f);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+        File f = new File(this.path, "sftpx400-credential.json");
+        System.out.println("Reading from " + f.getAbsolutePath());
+        try {
+            return new SFTPX400(f);
         } catch (Exception e) {
             System.out.println(e.getMessage());
             return null;

--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/common/ResultDispatch.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/common/ResultDispatch.java
@@ -209,6 +209,9 @@ public class ResultDispatch {
     void sendSFPTX400(File file, String messageId) {
         try {
             com.ywesee.java.yopenedi.common.SFTPX400 sftpConfig = this.config.getSFTPX400Credential();
+            if (sftpConfig == null) {
+                System.out.println("Credential for SFTP X.400 not found, skipping");
+            }
             JSch jsch = new JSch();
             String privateKeyPath = new File(sftpConfig.privateKeyPath).getAbsolutePath();
             System.out.println("SFTP X.400 privateKeyPath: " + privateKeyPath);

--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/common/ResultDispatch.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/common/ResultDispatch.java
@@ -56,6 +56,10 @@ public class ResultDispatch {
         // e.g. "cn=xxxxx; s=yyyyy; o=zzzzzz-gmbh; p=AAAAA; a=VIAT; c=DE"
         String toAddress;
         String toUserId;
+        SFTPX400(JSONObject obj) {
+            this.toAddress = (String)obj.getOrDefault("to", null);
+            this.toUserId = (String)obj.getOrDefault("toUserId", null);
+        }
     }
     class Filter {
         ArrayList<String> glns = null;
@@ -110,6 +114,9 @@ public class ResultDispatch {
         }
         if (obj.containsKey("email")) {
             this.emailDest = new EmailDest((JSONObject)obj.get("email"));
+        }
+        if (obj.containsKey("sftp-x400")) {
+            this.sftpx400 = new SFTPX400((JSONObject) obj.get("sftp-x400"));
         }
     }
 

--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/common/ResultDispatch.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/common/ResultDispatch.java
@@ -156,6 +156,7 @@ public class ResultDispatch {
         prop.put("mail.smtp.host", emailCreds.smtpHost);
         prop.put("mail.smtp.port", emailCreds.smtpPort);
         prop.put("mail.smtp.auth", "true");
+        prop.put("mail.smtp.protocols", "TLSv1.2 TLSv1.3");
         if (emailCreds.secure) {
             prop.put("mail.smtp.starttls.enable", "true"); //TLS
         }

--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/common/SFTPX400.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/common/SFTPX400.java
@@ -1,0 +1,28 @@
+package com.ywesee.java.yopenedi.common;
+
+import org.apache.commons.io.FileUtils;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.File;
+import java.io.IOException;
+
+public class SFTPX400 {
+    public String host;
+    public String username;
+    public String privateKeyPath;
+    public String knownHosts;
+    public String messageFolder;
+
+    public SFTPX400(File file) throws IOException, ParseException {
+        String str = FileUtils.readFileToString(file, "UTF-8");
+        JSONParser parser = new JSONParser();
+        JSONObject obj = (JSONObject)parser.parse(str);
+        this.host = (String)obj.get("host");
+        this.username = (String)obj.get("username");
+        this.privateKeyPath = (String)obj.get("privateKeyPath");
+        this.knownHosts = (String)obj.getOrDefault("knownHosts", null);
+        this.messageFolder = (String)obj.getOrDefault("messageFolder", null);
+    }
+}

--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/converter/Converter.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/converter/Converter.java
@@ -63,7 +63,9 @@ public class Converter {
                     Order otOrder = orderToOpenTrans(ediOrder);
                     return new Pair<>(pair.snd, otOrder);
             }
-        } catch (Exception e) {}
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         return null;
     }
 

--- a/java/email-fetcher/build.gradle
+++ b/java/email-fetcher/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     // https://mvnrepository.com/artifact/commons-io/commons-io
     compile group: 'commons-io', name: 'commons-io', version: '2.7'
     implementation 'commons-cli:commons-cli:1.4'
+    implementation 'com.jcraft:jsch:0.1.55'
 
     compile project(':converter')
     // Use JUnit test framework

--- a/java/email-fetcher/src/main/java/com/ywesee/java/yopenedi/emailfetcher/App.java
+++ b/java/email-fetcher/src/main/java/com/ywesee/java/yopenedi/emailfetcher/App.java
@@ -195,6 +195,7 @@ public class App {
         properties.setProperty("mail.imap.port", emailCreds.imapPort);
         properties.setProperty("mail.imap.connectiontimeout", "5000");
         properties.setProperty("mail.imap.timeout", "5000");
+        properties.setProperty("mail.imap.ssl.protocols", "TLSv1.2 TLSv1.3");
 
         Session imapSession = Session.getInstance(properties, null);
         if (showDebugMessages) {


### PR DESCRIPTION
#219 

Um zu Nachrichten hunterladen, wir müssen Username, Host usw. zu diesen Dateien setzen.

- `sftpx400-credential.json`
- `test-sftpx400-credential.json`

Um zu Nachrichten senden, wir müssen der Empfänger in `result-dispatch.json` hinzufügen.

```
{
  "filters": {
    "glns": [....]
  },
  "sftp-x400": {
    "toAddress": "cn=xxxxx; s=xxxxxx o=xxxxx-gmbh; p=XXXX; a=VIAT; c=DE",
    "toUserId": "00000000"
  }
}
```

Ich weiss nicht, ob ich solle die Username, Host usw. in Commit schreiben, also ich habe das nicht geschreiben. Falls es ist OK, ich kann eine neue Commit mit die Username, Host usw. machen.

Auch, wir benutzen [JSCH](http://www.jcraft.com/jsch/) für SFTP, es versteht nicht der Privatschlüssel in neue Format. Wir müssen es zu ein alter Format konvertieren. Wie so:
```
ssh-keygen -p -f ./dt_telekom -m pem -P "" -N "" 
```