### PR TITLE
Fix issue with not reading toAddress

### DIFF
--- a/java/converter/src/main/java/com/ywesee/java/yopenedi/common/ResultDispatch.java
+++ b/java/converter/src/main/java/com/ywesee/java/yopenedi/common/ResultDispatch.java
@@ -58,7 +58,7 @@ public class ResultDispatch {
         String toAddress;
         String toUserId;
         SFTPX400(JSONObject obj) {
-            this.toAddress = (String)obj.getOrDefault("to", null);
+            this.toAddress = (String)obj.getOrDefault("toAddress", null);
             this.toUserId = (String)obj.getOrDefault("toUserId", null);
         }
     }


### PR DESCRIPTION
#232  

Gemäss das Messagegate Handbuch
Error: (Reason: 6, Diagnostic: 0) ist "Unrecognized-OR-name".
In unser Log, es gibt `To: "" <x@viat.de>`, ich denke ich habe die `toAddress` nicht korrect gemacht.